### PR TITLE
Change sass to scss

### DIFF
--- a/process/README.md
+++ b/process/README.md
@@ -7,7 +7,7 @@ General
 -------
 
 * All code should be under source control.
-* Please don't check in build artifacts. (Don't check in css files if we are using sass). This always leads to pain and suffering.
+* Please don't check in build artifacts. (Don't check in css files if we are using scss). This always leads to pain and suffering.
 * All changes should go through source control and the deployment process.
 * Don't throw nerf darts at [Dom](http://seesparkbox.com/about/dominique_richardson/).
 
@@ -25,7 +25,7 @@ Repository Setup
 * The root of the repository should be reserved for the main deliverable for the project.
 * Planning documents should go in the "planning" folder in the root.
 * Templates (if they are not the main deliverable) should go in the "templates" for in the root.
-* Use the following directory names on the root of your work folder: 'sass', 'css', 'js', 'images'.
+* Use the following directory names on the root of your work folder: 'scss', 'css', 'js', 'images'.
 
 
 


### PR DESCRIPTION
The Process section says to prefer scss syntax over sass syntax, but it also says to put scss files in a sass directory.

I don't think this makes much sense.

This pull request suggests putting our scss files in a scss directory instead, which makes more sense.
