### PR TITLE
Documentation for standard npm scripts to use across projects

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -4,7 +4,7 @@
 * Developing
   * [Style](./style/README.md)
   * [Build & Deployment](./build_process/README.md)
-    * [General Best Practices](./build_process/general.md)
+    * [Node & NPM](./build_process/node.md)
 * Community
   * [Meetups](./meetups/README.md)
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -4,6 +4,7 @@
 * Developing
   * [Style](./style/README.md)
   * [Build & Deployment](./build_process/README.md)
+    * [General Best Practices](./build_process/general.md)
 * Community
   * [Meetups](./meetups/README.md)
 

--- a/build_process/README.md
+++ b/build_process/README.md
@@ -1,4 +1,5 @@
 Build Process
 ========
 
+* **[General Best Practices](general.md)**
 * **[Assemble](assemble)**

--- a/build_process/README.md
+++ b/build_process/README.md
@@ -1,5 +1,5 @@
 Build Process
 ========
 
-* **[General Best Practices](general.md)**
-* **[Assemble](assemble)**
+* **[Node & NPM](./node.md)**
+* **[Assemble](assemble/README.md)**

--- a/build_process/README.md
+++ b/build_process/README.md
@@ -1,5 +1,9 @@
-Build Process
+Build and Deployment
 ========
 
-* **[Node & NPM](./node.md)**
-* **[Assemble](assemble/README.md)**
+We believe that the more frequently we deploy, the better we collaborate as
+team and with our clients to navigate our way towards the most appropriate
+outcome.
+
+Our expectation is that anyone of our development team should be able to build 
+and deploy within a few moments of cloning a project repository.

--- a/build_process/general.md
+++ b/build_process/general.md
@@ -1,0 +1,71 @@
+# General Best Practices
+
+## NPM Scripts
+
+Our projects use different build systems (Gulp, Grunt, custom, etc), but many times they have tasks that do  
+similar things on every project. As developers move from project to project we can save some cognitive overhead by  
+standardizing the commands we use for these common tasks. With node we can use  
+[npm scripts](https://docs.npmjs.com/misc/scripts) as shortcuts to our various common tasks.
+
+**Environment variables determine build type**
+
+Builds for various environments (dev/prod) can tend to multiply build tasks. Instead of using different commands for  
+dev and production builds we can use one standard command and use environment variables to determine the type of  
+build to execute.
+
+`npm start` - The start script should start up the web server on production or otherwise run and serve a development build
+
+**Running tests**
+
+`npm test` - Setup your tests to run with this standard task for that purpose
+
+**All other tasks**
+
+`npm run` - If we setup all of our other tasks as uniquely-named NPM scripts, developers can use this simple command  
+to quickly determine all other tasks available to them
+
+### `package.json`
+
+- The default 'npm start' command is configured to run the `start.js` file which has conditional logic to run either  
+a production server or development build based on an environment variable.
+- The `postinstall` script runs a production build so that the server is ready to serve immediately after deployment
+
+```
+{
+  "name": "sample-project",
+  "scripts": {
+    "start": "node start.js",
+    "prestart": "npm install",
+    "serve": "node app.js",
+    "dev": "[dev build/watch/serve scripts go here]",
+    "postinstall": "[production build scripts go here]",
+  },
+  "dependencies": {
+    "shelljs": "0.5.3",
+  }
+}
+```
+
+### `start.js`
+
+- The production server needs the `NODE_ENV` environment variable set to `production`
+- Using shell.js allows us to run npm scripts keeping all build tasks in `package.json`
+- If no `NODE_ENV` value is found, a development environment is assumed so that local developers can start building with a simple `npm start`
+
+
+```
+import shell from 'shelljs';
+
+let env = process.env.NODE_ENV;
+
+if (env === 'production') {
+  console.log('Starting Production...');
+  shell.exec('npm run serve');
+} else {
+  console.log('Starting Development...');
+  shell.exec('npm run dev');
+}
+```
+
+
+

--- a/build_process/node.md
+++ b/build_process/node.md
@@ -2,15 +2,18 @@
 
 ## NPM Scripts
 
-Our projects use different build systems (Gulp, Grunt, custom, etc), but many times they have tasks that do  
-similar things on every project. As developers move from project to project we can save some cognitive overhead by  
-standardizing the commands we use for these common tasks. With node we can use  
-[npm scripts](https://docs.npmjs.com/misc/scripts) as shortcuts to our various common tasks.
+Our projects use different build systems (Gulp, Grunt, custom, etc), but many 
+times they have tasks that do similar things on every project. As developers 
+move from project to project we can save some cognitive overhead by 
+standardizing the commands we use for these common tasks. With node we can use 
+[npm scripts](https://docs.npmjs.com/misc/scripts) as shortcuts to our various 
+common tasks.
 
 **Environment variables determine build type**
 
-Builds for various environments (dev/prod) can tend to multiply build tasks. Instead of using different commands for  
-dev and production builds we can use one standard command and use environment variables to determine the type of  
+Builds for various environments (dev/prod) can tend to multiply build tasks. 
+Instead of using different commands for dev and production builds we can use 
+one standard command and use environment variables to determine the type of 
 build to execute.
 
 `npm start` - The start script should start up the web server on production or otherwise run and serve a development build
@@ -21,12 +24,13 @@ build to execute.
 
 **All other tasks**
 
-`npm run` - If we setup all of our other tasks as uniquely-named NPM scripts, developers can use this simple command  
-to quickly determine all other tasks available to them
+`npm run` - If we setup all of our other tasks as uniquely-named NPM scripts, 
+developers can use this simple command to quickly determine all other tasks 
+available to them.
 
 ### `package.json`
 
-- The default 'npm start' command is configured to run the `start.js` file which has conditional logic to run either  
+- The default 'npm start' command is configured to run the `start.js` file which has conditional logic to run either
 a production server or development build based on an environment variable.
 - The `postinstall` script runs a production build so that the server is ready to serve immediately after deployment
 
@@ -66,6 +70,4 @@ if (env === 'production') {
   shell.exec('npm run dev');
 }
 ```
-
-
 

--- a/build_process/node.md
+++ b/build_process/node.md
@@ -1,4 +1,4 @@
-# General Best Practices
+# Node
 
 ## NPM Scripts
 


### PR DESCRIPTION
To reduce cognitive overhead in project switching, we should standardize a set of npm scripts to use for common tasks in all our projects.