### PR TITLE
docs: Update 'Slack' with channel guidelines

### DIFF
--- a/culture/README.md
+++ b/culture/README.md
@@ -1,6 +1,16 @@
 Culture
 =======
 
+At its core, Sparkbox is our people. We exist to inspire and empower a Web built right. We do this through our work with customers—crafting beautiful web products that inspire others to build right. We do this by sharing what we know—on [the Foundry](../foundry), in our Build Right trainings and workshops, and by speaking at industry events and writing for industry publications. We also do this by running apprenticeships—finding people who share our desire but lack our experience and pouring into them for the first six months of each year.
+
+Every new initiative is considered through this lens: whether it  will  inspire and empower a Web built right.
+
+
+## The Sparkbox Code of Conduct
+Sparkbox is dedicated to providing inclusive, harassment-free, work environment for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, or religion or lack thereof.
+We expect everyone to fully comply with these ideals at Sparkbox whenever they are representing the company. This includes when you are at the office (or your primary place of work) or when you are traveling for Sparkbox. This also includes when you are participating in social media or other industry related activities (ex: Github).
+Don’t be nasty or mean—be considerate and respectful.
+
 * **[Our Foundation](our-foundation/README.md)**
 * **[Our Space](our-space/README.md)**
 * **[Knowledge Sharing](knowledge-sharing/README.md)**

--- a/services/slack/README.md
+++ b/services/slack/README.md
@@ -3,26 +3,96 @@ Slack
 
 [![Image of Sack][producti]][product]
 
-Our team communication platform because we like to talk to each other.
+We use Slack to stay in touch with each other no matter where we are physically. It’s a great tool, and the following outlines a few tips to keep Slack useful—and navigable–for everyone.
 
 [product]: https://slack.com/
 [producti]: http://i.imgur.com/0u1iR8W.png
 
 ## Channels
 
-Slack allows us to create channels to talk to everyone at once, think chat room.
+Slack allows us to create channels to talk to everyone at once: think "chat room".
 
-### General & Random
+### #general & #random
 
-By default slack has two channels, General and Random, and all users are added. General is a place to talk about non work related stuff and Random is a scary place of pure randomness.
+By default slack has two channels, #general and #random, and all users are added. While #general is a place to talk about work related stuff, #random is a scary place of pure randomness.
+
+### Sparkbox channels
+Official "Sparkbox Sanctioned" channels begin with a `-`. See the note on prefixes below.
+
+##### #-awesomeness
+A channel for sharing awesome notes about coworkers.
+
+##### #-biz
+A place for **bizBot** to keep Sparkbox informed about business development.
+
+##### #-conferences
+The channel for sharing interesting conferences, Call for Speakers, and planning the conference you'd like to attend.
+
+##### #-dayton & #-pittsburgh
+Channels to discuss office-specific happenings, such as lunch plans.
+
+##### #-gems
+A collection of quotations from your Sparkbox community, curated in part by **gem-me-bot**. Share a gem publicly with the `:earth-americas:` reaction, or hide it from the public eye with the `:x:` response. There's even [a Foundry article](https://seesparkbox.com/foundry/sparkbox_gems) if you'd like to learn more.
+
+##### #-know-your-company
+A place to discuss fun facts about coworkers, along with weekly KYC email answers.
+
+##### #-sparkbox-pride
+Share your Sparkbox Pride, generally in photo form.
 
 ### Public Channels
 
-Additional channels have been created which any member of the Sparkbox team can join at any time. These channels cover a range of topics from discussion on design, to video games, to weekly lunches. Any member of the team can start a new channel or join an existing one. There are currently over 150 channels.
+Additional channels have been created which any member of the Sparkbox team can join at any time. These channels cover a range of topics from discussion on design, to video games, to weekly lunches. Any member of the team can start a new channel or join an existing one.
 
-### ext-
+### Creating New Channels
 
-Some channels begin with and ext-, these channels allow clients to join in on the conversation.
+There are obvious times to create a new channel, such as when a new client engagement starts. There are also not as obvious times. When deciding to create a new channel, ask yourself these questions:
+- Is this channel new and not covered by any existing channels? Have I asked in #general if a similar channel exists?
+- Will this channel reduce ongoing unrelated clutter in another channel?
+
+After you create a new channel, be sure to set a clear, concise channel purpose so that other Sparkboxers can easily understand what the channel is discussing.
+
+**Note: Public over Private** should be the default. Even if you feel the topic is only of interest to a small number of people, consumer filtering is preferred over producer filtered content. This allows everyone to see how and why decisions are made. Just like an open-source GitHub repo. Similarly, if you have a question for one person regarding a project or a technology that might be relevant to someone else on the team, consider asking that question in the proper public channel rather than a DM.
+
+### Naming Conventions
+
+#### Rule #1
+hyphens-not-underscores
+
+#### Rule #2
+all-lower-case
+
+#### Rule #3
+Including the year in a title name is generally unnecessary. This sets up a short-lived channels mindset. If you do find it necessary to set up one of those, it would be wise to go ahead and set up a calendar reminder to kill it when you likely know its usefulness would run out.
+
+#### Rule #4
+prefix-appropriately
+
+- `-` Important, common channels for everyone.
+The `-` ensures they go to the top of the channel list. A channel should get this prefix if everyone at Sparkbox would likely find value in belonging to it. *Example: `-biz`.*
+- `int-` Client Projects, "internal" Sparkboxer-only channels.
+- `ext-` Client Projects, "external" channels that may include the client team.
+- `temp-` Channels with a temporary purpose. You need something larger than a DM but it won’t be a permanent channel (example: conferences, Maker Series, etc.). Perhaps set up a calendar reminder to delete your channel later.
+
+### Pruning Channels
+
+Channels can quickly become unruly and difficult to navigate. We’ve recognized two reasons to archive a channel:
+
+- Redundancy: If two or more channels serve the same purpose, then decide on the one that is most popular/used, and delete the others.
+- Unused: If a channel has gone silent, then a vote will be called and requires three* people voting :hand: in order to keep the channel. If less than three people vote to keep the channel, then it should be archived.
+
+Unless a channel is redundant, the default action will be to archive it, because channels can be unarchived very easily. Since archived channels don’t shown in the channel listing, archiving is a safe way to remove visual clutter and cut down on searching while still leaving the option to resurrect that channel later.
+
+#### garbage_bot
+
+The bot user, @garbage_bot is a tool created by Patrick Simpson to identify unused channels on a quarterly basis. It will notify #random with a list of channels flagged for review.
+
+## Etiquette
+#### `@everyone`, `@channel`, or `@group`
+Try using `@here` to only notify online, desktop users. Alternatively, `@dayton` is useful to target only those in the Dayton office, or `@pittsburgh` for the Pittsburgh office. In any case, be respectful of the many people who will receive notifications, often to mobile devices on nightstands.
+
+#### Code of Conduct
+All Sparkbox employees are expected to follow the [Sparkbox Code of Conduct](../../culture) while participating in Slack. Treat it as you would physical office space.
 
 ## Direct Messages
 
@@ -41,3 +111,14 @@ Slack really likes to keep everyone in the loop so it shares Twitter notificatio
 ## The App
 
 We can stay in the loop even when we are out of the office with the [mobile app](https://itunes.apple.com/us/app/slack-team-communication/id618783545?mt=8).
+
+## Sparkbot
+
+Sparkbot is available for a number of helpful tasks. Direct message `@sparkbot` with `help` to see a full list of commands.
+
+### Resources
+- [Slack’s Guide to Managing Slack](https://slackhq.com/how-to-manage-your-slack-channels-38801ef651f2#.eo5pulg6t)
+- [Ember Slack Naming Conventions](https://github.com/cromwellryan/embercommunity-slack-guidelines#creating-new-channels)
+- [Fugue’s Slack](https://blog.fugue.co/2016-03-29-it-s-not-all-unicorns-and-rainbows-managing-slack-for-productivity.html)
+- [Controlled Vocabulary](https://en.wikipedia.org/wiki/Controlled_vocabulary)
+- [Controlled Vocabulary at Microsoft](Controlled Vocabulary at Microsoft)


### PR DESCRIPTION
Update the "Slack" section with the channel guidelines we have stored (until now) in Google Docs. 