### PR TITLE
Add .htaccess snippets for QA sites

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -3,6 +3,7 @@
 * Community
   * [Meetups]
 * [Planning]
+  * [Site Completeness Checklist]
 * Developing
   * [Style]
   * [Build & Deployment]
@@ -43,3 +44,4 @@
 [Device Security]: ./security/devices.md
 [Verified Git Commits]: ./security/verified-commits.md
 [Drops Process]: ./build_process/drops.md
+[Site Completeness Checklist]: ./project_management/site_completeness_checklist.md

--- a/build_process/htaccess_snippets.md
+++ b/build_process/htaccess_snippets.md
@@ -1,0 +1,28 @@
+# Adding access for Sparkbox users to QA instances
+
+Depending on your version of Apache, add one of the two snippets shown below to your `.htaccess` file wherever you are serving your QA site in order to allow all users on the Sparkbox network (in the office or signed into the VPN) to load your site without needing to use login credentials. Logging in will still be required for anyone not on the Sparkbox network.
+
+## Apache Version 2.2
+
+```
+AuthUserFile /path/to/.htpasswd
+AuthName "Restricted"
+AuthType Basic
+require valid-user
+Order allow,deny
+Allow from 64.56.115.10
+satisfy any
+```
+
+## Apache Version 2.4
+
+```
+AuthType Basic
+AuthName "Restricted access"
+AuthUserFile "/path/to/.htpasswd"
+SetEnvIF X-Forwarded-For "64.56.115.10" AllowIP
+<RequireAny>
+        Require env AllowIP
+        Require valid-user
+</RequireAny>
+```

--- a/build_process/htaccess_snippets.md
+++ b/build_process/htaccess_snippets.md
@@ -1,4 +1,4 @@
-# Adding access for Sparkbox users to QA instances
+# Whitelisting the Sparkbox Network on QA Sites
 
 Depending on your version of Apache, add one of the two snippets shown below to your `.htaccess` file wherever you are serving your QA site in order to allow all users on the Sparkbox network (in the office or signed into the VPN) to load your site without needing to use login credentials. Logging in will still be required for anyone not on the Sparkbox network.
 

--- a/project_management/site_completeness_checklist.md
+++ b/project_management/site_completeness_checklist.md
@@ -7,7 +7,7 @@
 * [ ] Automated Deployments
 * [ ] Preproduction Environments: Disallows indexing
 * [ ] Preproduction Environments: Require Basic Authentication
-* [ ] Preproduction Environments: Allow access without Basic Authentication for users on the Sparkbox network - [instructions] (./project_management/htaccess_snippets.md)
+* [ ] Preproduction Environments: Whitelist the Sparkbox network - [instructions] (./project_management/htaccess_snippets.md)
 * [ ] Purchase CMS license (if applicable)
 * [ ] Transition/Purchase Font accounts in Customer Specific Account
 

--- a/project_management/site_completeness_checklist.md
+++ b/project_management/site_completeness_checklist.md
@@ -7,6 +7,7 @@
 * [ ] Automated Deployments
 * [ ] Preproduction Environments: Disallows indexing
 * [ ] Preproduction Environments: Require Basic Authentication
+* [ ] Preproduction Environments: Allow access without Basic Authentication for users on the Sparkbox network - [instructions] (./project_management/htaccess_snippets.md)
 * [ ] Purchase CMS license (if applicable)
 * [ ] Transition/Purchase Font accounts in Customer Specific Account
 


### PR DESCRIPTION
This adds a .md file with the .htaccess snippets for allowing users on the Sparkbox network to directly access password protected QA sites. It also adds an entry in the Site Completeness Checklist for adding this to a QA site and a link to the snippets. I also took the opportunity here to add a direct link to the Site Completeness Checklist from the Summary, just to make it easier to find.