### PR TITLE
Forecast FAQs with additional content description

### DIFF
--- a/services/harvest/README.md
+++ b/services/harvest/README.md
@@ -3,4 +3,4 @@
 By default, Harvest's time format is in decimal. To change this (locally) enter the following command in terminal: 
 ```defaults write com.getharvest.harvestxapp TimeFormat hours_minutes```
 
-We use Harvest and Harvest's Forecast together to keep track of our client and internal investments. For more details and FAQs on the whats and whys of our tracking, here's a doc: https://docs.google.com/document/d/1__pDQBPCLq7zekS_31IKIT-ihHlwm0fmPt31aC1VDzQ/edit#
+We use Harvest and Harvest's Forecast together to keep track of our client and internal investments. For more details and FAQs on the whats and whys of our tracking, here's a doc (Sparkbox employees only): https://docs.google.com/document/d/1__pDQBPCLq7zekS_31IKIT-ihHlwm0fmPt31aC1VDzQ/edit#


### PR DESCRIPTION
Added "Sparkbox employees only" so as to not confuse the public why they can't access a private doc in a public repo.