### PR TITLE
feat: Enable I18n support for non-ASCII characters

### DIFF
--- a/software/apache/README.md
+++ b/software/apache/README.md
@@ -68,6 +68,7 @@ Change the `Listen` setting from `8080` to `80`.
 ### Enable Apache Modules
 Uncomment out the following lines (they will not be together):
 
+    LoadModule xml2enc_module lib/httpd/modules/mod_xml2enc.so
     LoadModule rewrite_module lib/httpd/modules/mod_rewrite.so
     LoadModule proxy_module lib/httpd/modules/mod_proxy.so
     LoadModule proxy_fcgi_module lib/httpd/modules/mod_proxy_fcgi.so


### PR DESCRIPTION
To resolve this notice, encountered after running `sudo apachectl -k restart` setting up seesparkbox on a new laptop:

[Tue Sep 18 10:56:15.729649 2018] [proxy_html:notice] [pid 82201] AH01425: I18n support in mod_proxy_html requires mod_xml2enc. Without it, non-ASCII characters in proxied pages are likely to display incorrectly.