### PR TITLE
docs: update apache project root example

### DIFF
--- a/software/apache/README.md
+++ b/software/apache/README.md
@@ -106,7 +106,7 @@ Each site will have its own _vhost_ file in `/usr/local/etc/httpd/vhosts`.
 
   * `<project_name>`: Domain safe name such as `seesparkbox`
   * `<php_port>`: Port to the PHP-FPM instance, such as `9071` for 7.1
-  * `<project_root>`: Web root such as `/projects/seesparkbox/static/dist`
+  * `<project_root>`: Web root such as `/projects/seesparkbox.com/ee`
 
   :warning: You should _not_ place your Apache projects under `~/Documents`. Apache
   requires both write and execute permissions on all paths in the site directory,


### PR DESCRIPTION
### Description
Update apache project root example to reflect the existing seesparkbox root.

Since we link to this doc in the seesparkbox setup docs (and already use seesparkbox as an example in the doc), it's nice to have the correct project root to plug into the `.conf` file we make.