### PR TITLE
📝docs: update table of contents and link cms docs together

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ How we dance.
 * **[Code Style](/code-style/README.md)** _The way we write documentation and code._
 * **[Culture](/culture)** _How we Sparkbox._
 * **[Foundry](/foundry)** _How we write on the Foundry._
+* **[Hosting](/hosting)** _How we work with servers._
 * **[Meetups](/meetups)** _Our MO for preparing and facilitating meetups._
+* **[Office](/office)** _How we interact with traditional office supplies and services._
 * **[Project Management](/project_management/README.md)** _How we manage our projects._
 * **[Security](/security)** _How we keep safe._
 * **[Services we Use](/services)** _Dropbox, Skype, etc._

--- a/software/README.md
+++ b/software/README.md
@@ -7,4 +7,4 @@ Software [we](https://seesparkbox.com) prefer to use when the need arises.
 * **[SSH](ssh)**
 * **[Vim](vim)**
 * **[Sublime](sublime)**
-* **[Expression Engine](expression_engine)**
+* **[CMS Platforms](cms)**

--- a/software/cms/README.md
+++ b/software/cms/README.md
@@ -1,6 +1,8 @@
 Content Management Systems
 ==========================
 
+See also [Platforms][].
+
 Drupal
 ------
 - Perfect for enterprise teams
@@ -33,3 +35,5 @@ Other CMSs
 Sparkbox also has extensive experience with:
 - ExpressionEngine ([website](https://expressionengine.com/))
 - WordPress ([website](https://wordpress.org/))
+
+[Platforms]: ../../platforms


### PR DESCRIPTION
A few sections seemed to be unlinked, relying solely on clickthrough of folders.

- Add hosting and office sections to main readme
- Connect Platforms to Services/CMS (I'm not sure if this was the best way to do that)