### PR TITLE
docs: Remove link to ExpressionEngine

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -7,4 +7,4 @@ Software [we](https://seesparkbox.com) prefer to use when the need arises.
 * **[SSH](ssh)**
 * **[Vim](vim)**
 * **[Sublime](sublime)**
-* **[Expression Engine](expression_engine)**
+


### PR DESCRIPTION
At some point the section to which this link linked was removed. Since
we have mostly moved on to other CMS suites I've opted to remove the
dead link rather than build that section back up.