### PR TITLE
Update markdown formatting to comply with our own markdown guidelines

### DIFF
--- a/build_process/assemble/README.md
+++ b/build_process/assemble/README.md
@@ -1,18 +1,15 @@
-Assemble
-========
+# Assemble
 
 ![Assemble Logo](https://avatars2.githubusercontent.com/u/2645080?s=140)
 
 The static site generator we use to build templates.
 
-Docs
------
+## Docs
 
   * [Assemble](http://assemble.io/docs/)
   * [Assemble Helpers](http://assemble.io/helpers/)
 
-Causes for common errors:
------
+## Causes for common errors:
 
 * If there is a conflict between values in our `YAML` data files and Handlebars helpers they often throw strange, unhelpful error messages. This can be fixed by scoping references in `hbs` files to the current object, for example: `this.icon` will avoid conflicts with the `icon` helper.
 

--- a/code-style/README.md
+++ b/code-style/README.md
@@ -1,5 +1,4 @@
-Code Style
-==========
+# Code Style
 
 * **[All Code](all_code)**
 * **[Ruby](ruby)**

--- a/code-style/all_code/README.md
+++ b/code-style/all_code/README.md
@@ -1,5 +1,4 @@
-All Code
-========
+# All Code
 
 ![Code Quality][xkcd]
 

--- a/code-style/code_reviews/README.md
+++ b/code-style/code_reviews/README.md
@@ -1,22 +1,15 @@
-Code Review Process
-=====
+# Code Review Process
 
 Code reviews should be happening at different stages in our development process.
 
-
-In the Flow
------
+## In the Flow
 
 Please utilize other Sparkboxers while you are working. Bounce ideas off of each other, get feedback, ask questions, debate different opinions. It's this level of care and detail about how the web should be built that has helped make us who we are. Debates on semantic class names, proper HTML elements, the right way to test something, etc. are always welcome and encouraged. Just keep it positive and friendly, and we will help to enrich and teach each other.
 
-
-Pull Requests
------
+## Pull Requests
 
 PRs are the perfect place for code reviews to happen. Please use these as a place to ask questions about how/why things are done, make suggestions, give praise for an awesome solution to a problem, or use that new animated GIF that you've been dying to show off. Conversations here will only lead to better products in the end.
 
-
-The Lone Wolf
------
+## The Lone Wolf
 
 Don't be a one person wolf pack. If for some reason we have a project with only one active team member, they should have PRs reviewed by another Sparkboxer. This gives that user someone else to bounce ideas off of and have some discussion about the project. It also keeps at least one other person up to speed on the project.

--- a/code-style/markdown/README.md
+++ b/code-style/markdown/README.md
@@ -1,49 +1,47 @@
-Markdown
-========
+# Markdown
 
 [![The Markdown Mark][producti]][product]
 
 Markdown is a terse markup langauge that produces HTML.
 
-Style
------
+## Style
 
 * Prefer footnotes to inline [links][links]
 
-    ```markdown
-    // bad
-    Sweet [link](http://linkzilla.biz) coming.
+  ```markdown
+  // bad
+  Sweet [link](http://linkzilla.biz) coming.
 
-    // good
-    Sweet [link][link] coming.
+  // good
+  Sweet [link][link] coming.
 
-    [link]: http://linkzilla.biz
+  [link]: http://linkzilla.biz
 
-    // also good
-    Sweet [link][] coming.
+  // also good
+  Sweet [link][] coming.
 
-    [link]: http://linkzilla.biz
-    ```
+  [link]: http://linkzilla.biz
+  ```
 
 * Use hash marks for consistent header markup
 
-    ```markdown
-    // bad
-    Hey There Big Boy
-    =================
+  ```markdown
+  // bad
+  Hey There Big Boy
+  =================
 
-    Check Out My H2
-    ---------------
-    
-    ### Inconsistent H3
+  ## Check Out My H2
 
-    // good
-    # Hey There Big Boy
+  ### Inconsistent H3
 
-    ## Check Out My H2
-    
-    ### My H3 looks like everything else now
-    ```
+  // good
+
+  # Hey There Big Boy
+
+  ## Check Out My H2
+
+  ### My H3 looks like everything else now
+  ```
 
 [product]: http://daringfireball.net/projects/markdown/
 [producti]: http://i.imgur.com/TUYGZBI.png

--- a/code-style/pattern_libraries/README.md
+++ b/code-style/pattern_libraries/README.md
@@ -1,5 +1,4 @@
-Pattern Libraries
-=====
+# Pattern Libraries
 
 What do we consider a "[pattern library](https://seesparkbox.com/foundry/building_pattern_libraries_in_react_with_storybook)" to be, exactly? At Sparkbox, our pattern libraries typically consist of all of the "components" that make up a project. We usually combine those components into larger pieces or entire "pages" so that we have some kind of static representation of how the components are used.
 
@@ -7,25 +6,27 @@ Ultimately, what we end up with is a guide for those who are implementing those 
 
 Keep in mind: you're creating a living tool to give guidance to others. Put into a pattern library what you would hope to get out of a pattern library if you were building new components or pages in a project.
 
-Tools
------
+## Tools
 
 ### Current tools
+
 We currently use [Downpour](https://github.com/sparkbox/downpour), which is our own implementation of Cloud Four's [Drizzle](https://github.com/cloudfour/drizzle) tool. Downpour and Drizzle are JavaScript-based tools that use [Handlebars](http://handlebarsjs.com/) for templating.
 
 For React-based projects, we've used [React Storybook](https://storybook.js.org/)
 
 ### Other tools
+
 - [Fabricator](https://fbrctr.github.io/)
 - [Pattern Lab](http://patternlab.io/)
 
-Naming Conventions
------
+## Naming Conventions
 
 ### Naming Overview
+
 When naming a component, first try to think about the places where the component will be used, and if variants of that component will need to be created. If a component is likely to be used in more than one place or in more than one context, you may want to be a bit more generic when naming it.
 
 If you're creating a very generic component — a "button" component, perhaps — you should create a "buttons" directory in your project, and then create a `base` file that will allow you to create variations off of the base component by passing Handlebars literal values into it (ex: `{{agree_button "My Text" class="my-class" visible=true counter=4}}`)
 
 ### UI & Other Components
+
 A project's pattern library reflects the vocabulary of both the project itself and the organization. When naming components that reflect the project's UI, you might find it helpful to consult the design comp, and to talk with the rest of your team and even the client.

--- a/code-style/rails/README.md
+++ b/code-style/rails/README.md
@@ -1,17 +1,14 @@
-Rails
-=====
+# Rails
 
 [![The Ruby on Rails Logo][producti]][product]
 
-We use Ruby on Rails as the back-end for most of our custom apps.
+We use Ruby on Rails as the back-end for many of our custom apps.
 
-Style
------
+## Style
 
 * Follow the [The Rails Style Guide][rails_style].
 
-Gems
-----
+## Gems
 
 We use these gems in most of our projects.
 
@@ -21,8 +18,7 @@ We use these gems in most of our projects.
 * [SASS](http://sass-lang.com/) for CSS
 * [Simple Form](https://github.com/plataformatec/simple_form) for forms
 
-Services
---------
+## Services
 
 We use these services with our Rails projects.
 

--- a/code-style/readme/README.md
+++ b/code-style/readme/README.md
@@ -1,12 +1,10 @@
-Readme
-======
+# Readme
 
 The `README.md` file in our project's root folder is the central location for
 all information about the project. The template below is the starting point for
 all new projects at Sparkbox.
 
-Template
---------
+## Template
 
 A file in the root of your project called `README.md`.
 

--- a/code-style/ruby/README.md
+++ b/code-style/ruby/README.md
@@ -1,15 +1,12 @@
-Ruby
-====
+# Ruby
 
 [![The Ruby Gem][producti]][product]
 
 Ruby is often our back-end language of choice. We use [Ruby on Rails][rails] for the server side implementation on many of our custom applications.
 
-Style
------
+## Style
 
 * Follow the [The Ruby Style Guide][ruby_style].
-
 
 [product]: http://www.ruby-lang.org/en/
 [producti]: http://i.imgur.com/EUW07BU.gif

--- a/code-style/scss/README.md
+++ b/code-style/scss/README.md
@@ -1,5 +1,4 @@
-Naming Conventions
-=====
+# Naming Conventions
 
 We follow [SMACSS](http://smacss.com/) conventions when naming CSS classes.
 When you are naming something, **do not** name it based on its content, as this will be difficult to

--- a/culture/README.md
+++ b/culture/README.md
@@ -1,12 +1,11 @@
-Culture
-=======
+# Culture
 
 At its core, Sparkbox is our people. We exist to inspire and build a better web. We do this through our work with customers—crafting beautiful web products that inspire others to build right. We do this by sharing what we know—on [the Foundry](../foundry), in our Build Right trainings and workshops, and by speaking at industry events and writing for industry publications. We also do this by running apprenticeships—finding people who share our desire but lack our experience and pouring into them for the first six months of each year.
 
-Every new initiative is considered through this lens: whether it  will  inspire and empower a Web built right.
-
+Every new initiative is considered through this lens: whether it will inspire and empower a Web built right.
 
 ## The Sparkbox Code of Conduct
+
 Sparkbox is dedicated to providing inclusive, harassment-free, work environment for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, or religion or lack thereof.
 We expect everyone to fully comply with these ideals at Sparkbox whenever they are representing the company. This includes when you are at the office (or your primary place of work) or when you are traveling for Sparkbox. This also includes when you are participating in social media or other industry related activities (ex: Github).
 Don’t be nasty or mean—be considerate and respectful.

--- a/culture/food-and-drink/README.md
+++ b/culture/food-and-drink/README.md
@@ -1,5 +1,4 @@
-Food & Drink
-============
+# Food & Drink
 
 - **Friday Lunches**
 - **Snacks**

--- a/culture/how-we-play/README.md
+++ b/culture/how-we-play/README.md
@@ -1,5 +1,4 @@
-How We Play
-============
+# How We Play
 
 - **Volley Pong**
 - **Parties**

--- a/culture/knowledge-sharing/README.md
+++ b/culture/knowledge-sharing/README.md
@@ -1,5 +1,4 @@
-Knowledge Sharing
-=================
+# Knowledge Sharing
 
 - **[Foundry](../../foundry)**
 - **Apprenticeships**

--- a/culture/our-foundation/README.md
+++ b/culture/our-foundation/README.md
@@ -1,5 +1,4 @@
-Our Foundation
-==============
+# Our Foundation
 
 - **Values**
   - Fluency
@@ -12,6 +11,6 @@ Our Foundation
 - **KYC**
 - **Inclusiveness**
   - What is acceptable behavior?
-  - How can we make *everyone* feel welcome?
+  - How can we make _everyone_ feel welcome?
   - Where to have sensitive conversations
 - **Benefits & Handbook**

--- a/culture/our-space/README.md
+++ b/culture/our-space/README.md
@@ -1,5 +1,4 @@
-Our Space
-=========
+# Our Space
 
 - **Device Wall**
 - **Makerbox**

--- a/foundry/README.md
+++ b/foundry/README.md
@@ -1,5 +1,4 @@
-Foundry
-=======
+# Foundry
 
-* **[Foundry Governance](foundry_governance.md)**
-* **[Foundry Composition](Foundry-composition.md)**
+- **[Foundry Governance](foundry_governance.md)**
+- **[Foundry Composition](Foundry-composition.md)**

--- a/hosting/README.md
+++ b/hosting/README.md
@@ -1,4 +1,3 @@
-Server Hosting
-===============
+# Server Hosting
 
 [See this document for server naming conventions](naming_conventions/servers.md)

--- a/meetups/README.md
+++ b/meetups/README.md
@@ -1,62 +1,66 @@
-Meetups
-=====
+# Meetups
 
 How to run a meetup at Sparkbox.
 
-Website/Calendar
--------
+## Website/Calendar
 
- - Parking - Someone needs to speak with the autobody shop next door to find out if they are ok with people parking there, and we should let them know the schedule.
- - Know/distribute Topic at least 3 weeks in advance (to have it before prior meetup would be ideal, so we can also announce at that)
- - Include the topics list
- - Backup topic
+- Parking - Someone needs to speak with the autobody shop next door to find out if they are ok with people parking there, and we should let them know the schedule.
+- Know/distribute Topic at least 3 weeks in advance (to have it before prior meetup would be ideal, so we can also announce at that)
+- Include the topics list
+- Backup topic
 
-Buildup
--------
+## Buildup
 
 **3 weeks before**
- - Email [Speaker Prep][speaker_prep]
- - Buffer tweets for next meetup (3wk topic, 1wk RSVP, day of feedback form)
 
-Day Of Meetup
--------
+- Email [Speaker Prep][speaker_prep]
+- Buffer tweets for next meetup (3wk topic, 1wk RSVP, day of feedback form)
+
+## Day Of Meetup
 
 **9am**
- - [ ] Print this
- - [ ] Organize seats & food tables
- - [ ] Make sure we have drinks
- - [ ] Write upcoming events on the wall
- - [ ] Order food for 12pm
+
+- [ ] Print this
+- [ ] Organize seats & food tables
+- [ ] Make sure we have drinks
+- [ ] Write upcoming events on the wall
+- [ ] Order food for 12pm
 
 **11am**
- - [ ] Signs on doors
- - [ ] Have a round-the-room question (best robot movie character, fav language, etc)
+
+- [ ] Signs on doors
+- [ ] Have a round-the-room question (best robot movie character, fav language, etc)
 
 **11:15am**
- - [ ] Ask round-the-room question
+
+- [ ] Ask round-the-room question
 
 **11:30am**
- - [ ] Announce upcoming events, meetups
- - [ ] Start video recording (as needed)
- - [ ] Start screen recording (as needed)
- - [ ] Introductions
- 
+
+- [ ] Announce upcoming events, meetups
+- [ ] Start video recording (as needed)
+- [ ] Start screen recording (as needed)
+- [ ] Introductions
+
 **12:00**
- - [ ] Food in building
+
+- [ ] Food in building
 
 **1pm**
- - [ ] Cleanup (from all the food mess, etc)
 
-Food
--------
+- [ ] Cleanup (from all the food mess, etc)
+
+## Food
 
 #### Pizza
 
 _Oregon Express (937-223-9205)_
-* 2x Ranchero
-* 2x BLT
-* 1x Reuben
-* 1x Veggie
+
+- 2x Ranchero
+- 2x BLT
+- 1x Reuben
+- 1x Veggie
 
 _Wheat Penny (937.496.5268)_
-* 1x Sicilian Gluten Free                                 
+
+- 1x Sicilian Gluten Free

--- a/naming_conventions/servers.md
+++ b/naming_conventions/servers.md
@@ -1,5 +1,4 @@
-Server Naming Conventions
-==========================
+# Server Naming Conventions
 
 Servers should be named consistently and in a manner in which they can be easily identifiable with regard to the client/property and purpose that they serve. We recommend the following naming conventions when creating/building new servers:
 
@@ -9,16 +8,16 @@ Servers should be named consistently and in a manner in which they can be easily
 
 - `domain-or-client-name`: this should be the name of the domain or client name the server will support, i.e. `seesparkbox.com`, `merchantssecurity` or `dpandl`
 - `server-type`: this should be an acronym or short description of the type of server it is, which should typically be one of the following:
-    - `web`: web server
-    - `db`: database server
-    - `lb`: load balancer
-    - `app`: dedicated application server
+  - `web`: web server
+  - `db`: database server
+  - `lb`: load balancer
+  - `app`: dedicated application server
 - `xx`: the two-digit server instance number, starting with `01` and increasing by 1 incrementally
 - `environment`: this should be the environment designation for the server, should typically be one of the following:
-    - `prod`: production servers
-    - `qa`: QA servers
-    - `staging`: staging and client testing servers
-    - `dev`: development and testing servers
+  - `prod`: production servers
+  - `qa`: QA servers
+  - `staging`: staging and client testing servers
+  - `dev`: development and testing servers
 
 ### Examples
 

--- a/office/printer.md
+++ b/office/printer.md
@@ -1,5 +1,4 @@
-Printing
-========
+# Printing
 
 [![Image of the Product][printeri]][instructions]
 

--- a/platforms/cms.md
+++ b/platforms/cms.md
@@ -1,15 +1,12 @@
 # CMS Platforms
 
-
 For many years, Sparkbox has relied on and recommended [ExpressionEngine] as the CMS of choice. In fact, ExpressionEngine continues to power https://seesparkbox.com. Today, we recommend one of two CMS platforms:
-
 
 ## [CraftCMS]
 
 "EE" proved flexible, extensible, customizable, and powerful for many years. As it's de-facto successor, [CraftCMS] builds on the strengths of ExpressionEngine, while making first class many of the features for which the [Pixel and Tonic plugins][pixelandtonic] were renowned.
 
 [Read about Sparkbox best practices and recommendations](./craftcms.md)
-
 
 ## [Drupal]
 

--- a/services/1password/README.md
+++ b/services/1password/README.md
@@ -1,5 +1,4 @@
-[1Password][1password]
-=====
+# [1Password][1password]
 
 [![1password][1password_image]][1password]
 
@@ -8,7 +7,7 @@ We use 1Password to keep our logins, passwords, notes, databases, and servers se
 > With great power comes great responsibility
 > ~ Uncle Ben
 
-Authenticated assets for Sparkbox and many of our clients are maintained in 1Password.  Be mindful of this and use appropriately.
+Authenticated assets for Sparkbox and many of our clients are maintained in 1Password. Be mindful of this and use appropriately.
 
 [1password]: https://1password.com
 [1password_image]: ./1Password.png

--- a/services/README.md
+++ b/services/README.md
@@ -1,5 +1,4 @@
-Services
-========
+# Services
 
 The services we use. Some we pay for, others we mooch off. We love them all.
 

--- a/services/alfred/README.md
+++ b/services/alfred/README.md
@@ -1,5 +1,4 @@
-Alfred
-======
+# Alfred
 
 [![Image of Alfred][alfred_image]][alfred]
 

--- a/services/browserstack/README.md
+++ b/services/browserstack/README.md
@@ -1,5 +1,4 @@
-BrowserStack
-============
+# BrowserStack
 
 [![Image of BrowserStack][browserstack_image]][browserstack]
 

--- a/services/circleci/README.md
+++ b/services/circleci/README.md
@@ -1,5 +1,4 @@
-CircleCI
-========
+# CircleCI
 
 [![Image of CircleCI][producti]][product]
 

--- a/services/code_climate/README.md
+++ b/services/code_climate/README.md
@@ -1,5 +1,4 @@
-Code Climate
-============
+# Code Climate
 
 [![Code Climate's Logo][producti]][product]
 

--- a/services/codepen/README.md
+++ b/services/codepen/README.md
@@ -1,5 +1,4 @@
-Codepen
-=======
+# Codepen
 
 [![Image of CodePen][codepen_logo]][codepen]
 

--- a/services/dropbox/README.md
+++ b/services/dropbox/README.md
@@ -1,19 +1,15 @@
-Dropbox
-=======
+# Dropbox
 
 ![Dropbox Website](http://i.imgur.com/w4R4VZP.png)
 
-
-Folders we Share
-----------------
+## Folders we Share
 
 * **Sparbox Bookshelf**
 * **Developer Videos**
 * **SoftwareLicenses**
 * [**SparkboxVault**][sparkbox_1password] 1password vault for shared credentials, servers and identities.
 
-How to Get Invited
-------------------
+## How to Get Invited
 
 The longer someone has been at the company the more of these folders they have
 access to. So far, Dropbox has no public listing of these directories. Maybe

--- a/services/invision/README.md
+++ b/services/invision/README.md
@@ -1,5 +1,4 @@
-InVision
-========
+# InVision
 
 [![Image of InVision][invision_image]][invision]
 

--- a/services/mailchimp/README.md
+++ b/services/mailchimp/README.md
@@ -1,5 +1,4 @@
-Mailchimp
-========
+# Mailchimp
 
 ![Image of Mailchimp](mailchimp.png)
 

--- a/services/sendgrid/README.md
+++ b/services/sendgrid/README.md
@@ -1,16 +1,15 @@
-SendGrid
-========
+# SendGrid
 
 [![SendGrid Logo][producti]][product]
 
 Our SMTP provider of choice.
-
 
 ## Issues
 
 If emails look like they are being sent to SendGrid, but aren't being delivered and aren't showing in the logs, then they're probably being deferred.
 
 Click on `Email Activity` in the navbar, then under `Search Options` select `Deferred`. If the emails that are being lost show up here with:
+
 ```
 Reason: 553 4.1.8 : Domain of sender address bounces+24253-e2e9-emailname=some_domain.com@email.seesparkbox.com does not resolve.
 ```
@@ -18,6 +17,7 @@ Reason: 553 4.1.8 : Domain of sender address bounces+24253-e2e9-emailname=some_d
 then there is most likely a DNS issue.
 
 _Solution:_
+
 - Click on the `Developers` link in the navbar.
 - Click `Whitelabel Wizard` in the right side nav.
 - Walk through the steps and ensure that the DNS records have been added to [dnsimple][dnsimple].

--- a/services/slack/README.md
+++ b/services/slack/README.md
@@ -1,5 +1,4 @@
-Slack
-========
+# Slack
 
 [![Image of Sack][producti]][product]
 

--- a/services/zenhub/README.md
+++ b/services/zenhub/README.md
@@ -1,0 +1,12 @@
+# Zenhub
+
+[![Image of Zenhub][zenhub_image]][zenhub]
+
+Zenhub is an agile project management tool that integrates seamlessly into GitHub. Browser [extensions] are available for Chrome and Firefox.
+
+![Image of boards view][zenhub_boards]
+
+[zenhub]: https://www.zenhub.com/
+[zenhub_image]: ./zenhub.png
+[extensions]: https://www.zenhub.com/extension
+[zenhub_boards]: ./zenhub__boards-view.jpg

--- a/software/README.md
+++ b/software/README.md
@@ -1,5 +1,4 @@
-Software
-========
+# Software
 
 Software [we](https://seesparkbox.com) prefer to use when the need arises.
 

--- a/software/cms/README.md
+++ b/software/cms/README.md
@@ -1,10 +1,7 @@
-Content Management Systems
-==========================
+# Content Management Systems
 
-See also [Platforms][].
+## Drupal
 
-Drupal
-------
 - Perfect for enterprise teams
 - Runs on PHP
 - Highly customizable
@@ -12,8 +9,8 @@ Drupal
 
 ([website](https://www.drupal.org/))
 
-Craft
------
+## Craft
+
 - Perfect for small teams & startups
 - Runs on PHP
 - Highly customizable
@@ -21,8 +18,8 @@ Craft
 
 ([website](https://craftcms.com/))
 
-Squarespace
------------
+## Squarespace
+
 - Perfect for small teams & startups
 - Website builder with the option to customize some code
 - Moderately customizable
@@ -30,10 +27,9 @@ Squarespace
 
 ([website](https://www.squarespace.com/))
 
-Other CMSs
-----------
+## Other CMSs
+
 Sparkbox also has extensive experience with:
+
 - ExpressionEngine ([website](https://expressionengine.com/))
 - WordPress ([website](https://wordpress.org/))
-
-[Platforms]: ../../platforms

--- a/software/sublime/README.md
+++ b/software/sublime/README.md
@@ -1,5 +1,4 @@
-Sublime
-=======
+# Sublime
 
 ![Sublime in Action](http://i.imgur.com/45niD1Y.jpg)
 

--- a/software/vim/README.md
+++ b/software/vim/README.md
@@ -1,12 +1,10 @@
-Vim
-===
+# Vim
 
 ![Vim is Rad by Ethan Muller](http://i.imgur.com/afOyr6p.png)
 
 _Vim is Rad by Ethan Muller_
 
-Sparkbox Configs
-----------------
+## Sparkbox Configs
 
 Many Sparkbox employees have published their custom Vim configuration to
 GitHub. Here are a few for your edification.


### PR DESCRIPTION
Brings our Markdown formatting into compliance with the rules in [our own guidelines](https://github.com/sparkbox/standard/tree/master/code-style/markdown). Yay we're not hypocrites anymore.

These changes are all formatting related. They shouldn't affect the content at all.