### PR TITLE
docs: 2018 update for harvest time format

### DIFF
--- a/services/harvest/README.md
+++ b/services/harvest/README.md
@@ -1,6 +1,30 @@
 # Harvest
 
-By default, Harvest's time format is in decimal. To change this (locally) enter the following command in terminal: 
+If you'd like to use the HH:MM format locally you can!
+
+### Prior to the 2017 Update
+
+By default, Harvest's time format is in decimal. To change this (locally) enter the following command in terminal:
 ```defaults write com.getharvest.harvestxapp TimeFormat hours_minutes```
 
-We use Harvest and Harvest's Forecast together to keep track of our client and internal investments. For more details and FAQs on the whats and whys of our tracking, here's a doc (Sparkbox employees only): https://docs.google.com/document/d/1__pDQBPCLq7zekS_31IKIT-ihHlwm0fmPt31aC1VDzQ/edit#
+### 2017 Update
+
+To read your settings, run:
+```
+defaults read ~/Library/Containers/com.getharvest.harvestxapp/Data/Library/Preferences/group.com.getharvest.Harvest.Documents.plist
+```
+
+To change the time format to HH:MM, run
+
+```
+defaults write ~/Library/Containers/com.getharvest.harvestxapp/Data/Library/Preferences/group.com.getharvest.Harvest.Documents.plist TimeFormat hours_minutes
+```
+
+Restart the Harvest App, and it should now display HH:MM (I tested this)
+
+To change back to decimal, run:
+```
+defaults write ~/Library/Containers/com.getharvest.harvestxapp/Data/Library/Preferences/group.com.getharvest.Harvest.Documents.plist TimeFormat decimal
+```
+
+Thanks to [this gist](https://gist.github.com/rcdilorenzo/ddee4da296e157e48b1efd0d1a193c3d)


### PR DESCRIPTION
Adding the info on how to setup HH:MM format on 2017 and up laptops. 
Using getharvest app for mac. 