### PR TITLE
Add Apprentice Curriculum

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ How we write code.
 How we dance.
 
 * **[Almanac](/almanac)** _Our list of browser bugs and quirks._
+* **[Apprenticeship](/apprenticeship)** _How we teach._
 * **[Build Process](/build_process)** _How we build, deploy, and deliver._
 * **[Code Style](/code-style/README.md)** _The way we write documentation and code._
 * **[Culture](/culture)** _How we Sparkbox._

--- a/apprenticeship/README.md
+++ b/apprenticeship/README.md
@@ -1,0 +1,20 @@
+# Apprenticeship
+
+Our vision for our apprenticeship program is to produce advanced beginners who are ready to contribute on real team web projects.
+
+We are a team that values education. We offer paid apprenticeships because we love what we do, we want to help create new talent, and we genuinely care about the future of the web.
+## Full-stack Apprenticeship
+
+In the first months of the full-stack apprenticeship, apprentices learn our convictions on priority of content, value of design, semantic HTML, and mobile-first CSS. Apprentices are exposed to our Github-centric project management, deployment processes, best practices for clean code and separation of concerns, and unit testing techniques.
+
+By the end of the apprenticeship, apprentices will be interacting as full-fledged developers. With new confidence, they'll have some work under their belt—and that’s when the real fun begins.
+
+Check out our [full-stack apprenticeship GitHub repository](https://github.com/sparkbox/apprenticeships) to get a really good sense of what our apprenticeship program looks like.
+
+## Frontend Designer Apprenticeship
+
+Our frontend design apprentices learn the skills needed to be a web designer in today’s quickly changing responsive web world. Apprentices start by learning to write semantic HTML and CSS and quickly progress to working on projects where they create wireframes and interface designs. We guide them through the iterative design process, point out things to keep in mind, and help them arrive at a compelling visual concept. During that process, apprentices learn to code their concepts like a pro, using Sass to help write, manage, and compile their CSS.
+
+By the end of the apprenticeship, apprentices will have the skills to function as a full-fledged frontend designer. They'll also have a couple of projects behind them and the knowledge needed to tackle what’s next.
+
+Check out a past [frontend designer apprenticeship curriculum](https://docs.google.com/document/d/1Xhe2M9yrif1uaE96DJcF1FXdsANLwjyro7Gf9vVnZz4/edit?usp=sharing) to get a really good sense of what our frontend designer apprenticeship is all about.

--- a/culture/knowledge-sharing/README.md
+++ b/culture/knowledge-sharing/README.md
@@ -1,7 +1,7 @@
 # Knowledge Sharing
 
 - **[Foundry](../../foundry)**
-- **Apprenticeships**
+- **[Apprenticeships](../../apprenticeship)**
 - **Maker Series**
 - **Lunch and learn**
 - **Speaking**


### PR DESCRIPTION
This is the first of a few steps to migrate the apprenticeship curriculum into the standard.

# Standard Structure
Your audience:
- New hires and current Sparkbox employees
- New clients via proposal documents

Unlike Foundry articles, these contributions are being created directly in Github, not in google docs.

**The goal for this first effort is to:** 
- [x] Add a section in the standard about the apprenticeship 
- [x] Add a paragraph or two that explains the program and introduces the curriculum we already have available publicly.
- [x] Link to the publicly available curriculum

The general structure we’re looking to create is **what→ why→ how**. This means it will start with what our process is from a high-level view. Then it will move on to the rationale for why this topic is important to Sparkbox and why we have come to the conclusions we have about it. Then it will dive down into a more detailed, task-based description of what we do, likely using bullet points or numbered lists.

# Writing Guidelines
These are some general writing guidelines to establish a consistent voice in the standard. Of course, I’ll be editing and ensuring final drafts sound like this, so don’t agonize over these. If you have any questions, shoot them my way!

Write in plural first person about Sparkbox. Refer to Sparkbox as “we” (example: We established this policy to create design consistency. Sparkbox follows these guidelines.)
Do NOT write in singular first person (bad example: In my job, I do...)
Do NOT write in second person (bad example: You should follow these guidelines.)
Write current policies and all tasks in present tense (example: We follow three guidelines. Click on the pencil icon.)
Write specific tasks as imperative actions without a subject 
(example: 1. Click on the lock icon. 2. Type the password. 3. Click log in)

