### PR TITLE
Minor spelling and formatting fixes

### DIFF
--- a/accessibility/introduction/README.md
+++ b/accessibility/introduction/README.md
@@ -21,7 +21,7 @@ Since we also know that usability testing is crucial, we are working on finding 
 
 **Sources**:
 * [W3C: WCAG 2.1 Reference]
-* [Deque: How to Get Development On Board with Accessibility Testing]how-to-get-development-on-board-with-accessibility-testing/
+* [Deque: How to Get Development On Board with Accessibility Testing]
 * [WebAIM: Accessibility User Testing]
 
 ## Accessibility is All or Nothing

--- a/how-we-work-together.md
+++ b/how-we-work-together.md
@@ -198,7 +198,7 @@ Many Sparkboxers are involved in initial staffing, budget, and timeline conversa
 
     * Discuss how the presented concept will help to accomplish the project goals
 
-    * If the client doesn’t agree with our rational, we listen and take every effort to address their concerns
+    * If the client doesn’t agree with our rationale, we listen and take every effort to address their concerns
 
     * We believe it is acceptable and our job to respectfully push back when we feel strongly that a client suggestion is detrimental to the project, and give reasons why
 


### PR DESCRIPTION
## Description
Fix some minor spelling and formatting issues.

## To Validate
- [x] Confirm that "rationale" makes more sense than "rational" in the context of the sentence
- [x] Confirm that the Deque link doesn't have extraneous text tailing after it, and that the link still works