### PR TITLE
docs: Update path for the `policy-checks` command

### DIFF
--- a/security/security_policy_compliance/README.md
+++ b/security/security_policy_compliance/README.md
@@ -21,7 +21,7 @@ If you wish, you can run the following in a terminal to check for
 [FileVault Full Disk Encryption].
 
 ```
-curl -s https://raw.githubusercontent.com/sparkbox/standard/master/security/security_policy_compliance/policy-checks.sh | sh
+curl -s https://raw.githubusercontent.com/sparkbox/standard/main/security/security_policy_compliance/policy-checks.sh | sh
 ```
 
 


### PR DESCRIPTION
# Description
Since the production branch has changed from `master` to `main`, we need to update the path to the policy checks shell script.

# Validation Steps
1. Using your eyeballs, confirm that the path to the `policy-checks.sh` file reflects the `main` branch instead of the `master` branch.