### PR TITLE
🔐  Backups are optional

### DIFF
--- a/security/security_policy_compliance/policy-checks.sh
+++ b/security/security_policy_compliance/policy-checks.sh
@@ -43,9 +43,12 @@ function validate_time_machine {
   start "Checking Time Machine Backup Disk Encryption"
 
   # Replace spaces with three underscores so we can use spaces as a delimiter in an array
+  TIME_MACHINE_CONFIGURATION=$(tmutil destinationinfo)
   TIME_MACHINE_VOLUMES=$(tmutil destinationinfo | grep -e "Name" | sed 's/Name.*: //' | sed -e "s/ /___/g")
 
-  if [ "${TIME_MACHINE_VOLUMES}" == "" ]; then
+  if [ "${TIME_MACHINE_CONFIGURATION}" == "tmutil: No destinations configured." ]; then
+    success "Backups are not configured. Encryption not required."
+  elif [ "${TIME_MACHINE_VOLUMES}" == "" ]; then
     warning "No backup disks configured with Time Machine." "https://github.com/sparkbox/standard/blob/main/security/security_policy_compliance/timemachine.md#first-time-setup"
   fi
 
@@ -55,7 +58,7 @@ function validate_time_machine {
     VOLUME_TYPE=$(get_volume_attribute "Type (Bundle)" "${VOLUME_INFO}")
 
     case $VOLUME_TYPE in
-      # APFS volumes will identify their encryption status under "FileValt"
+      # APFS volumes will identify their encryption status under "FileVault"
       "apfs")
         VOLUME_ENCRYPTED=$(get_volume_attribute "FileVault" "${VOLUME_INFO}")
         ;;

--- a/security/security_policy_compliance/policy-checks.sh
+++ b/security/security_policy_compliance/policy-checks.sh
@@ -39,65 +39,77 @@ function get_volume_attribute {
   echo $(echo "$HAYSTACK" | grep -e "$NEEDLE:" | cut -d : -f2 | sed 's/^ *//g')
 }
 
+function validate_time_machine {
+  start "Checking Time Machine Backup Disk Encryption"
+
+  # Replace spaces with three underscores so we can use spaces as a delimiter in an array
+  TIME_MACHINE_VOLUMES=$(tmutil destinationinfo | grep -e "Name" | sed 's/Name.*: //' | sed -e "s/ /___/g")
+
+  if [ "${TIME_MACHINE_VOLUMES}" == "" ]; then
+    warning "No backup disks configured with Time Machine." "https://github.com/sparkbox/standard/blob/main/security/security_policy_compliance/timemachine.md#first-time-setup"
+  fi
+
+  for VOLUME in $TIME_MACHINE_VOLUMES; do
+    VOLUME_NAME=$(echo ${VOLUME} | sed -e "s/___/ /g")
+    VOLUME_INFO=$(diskutil info "${VOLUME_NAME}" 2> /dev/null)
+    VOLUME_TYPE=$(get_volume_attribute "Type (Bundle)" "${VOLUME_INFO}")
+
+    case $VOLUME_TYPE in
+      # APFS volumes will identify their encryption status under "FileValt"
+      "apfs")
+        VOLUME_ENCRYPTED=$(get_volume_attribute "FileVault" "${VOLUME_INFO}")
+        ;;
+      # Core Storage volumes (Journaled HFS+) will identify their encryption status under "Encrypted"
+      *)
+        VOLUME_ENCRYPTED=$(get_volume_attribute "Encrypted" "${VOLUME_INFO}")
+        ;;
+    esac
+
+    case $VOLUME_ENCRYPTED in
+      Yes)
+        success "\"${VOLUME_NAME}\" is encrypted."
+        ;;
+      No)
+        fail "\"${VOLUME_NAME}\" is not encrypted." "https://github.com/sparkbox/standard/blob/main/security/timemachine.md"
+        ;;
+      *)
+        fail "Unable to locate \"${VOLUME_NAME}\". Please check your connection to this volume and try again."
+        ;;
+    esac
+  done
+}
+
+function validate_full_disk_encryption {
+  start "Checking for FileVault full disk encryption"
+  FILEVAULT_STATUS="$(fdesetup status)"
+
+  echo "${FILEVAULT_STATUS}" | grep 'FileVault is On' &> /dev/null
+  if [ $? != 0 ]; then
+    fail "${FILEVAULT_STATUS}" "https://github.com/sparkbox/standard/blob/main/security/filevault.md"
+  else
+    success "${FILEVAULT_STATUS}"
+  fi
+
+}
+
+function validate_software_updates {
+  start "Checking for software updates"
+  UPDATE_LIST="$(sudo softwareupdate -l 2>&1)"
+  UPDATE_STATUS="$(echo "${UPDATE_LIST}" | grep 'No new software available\.')"
+
+  if [ "${UPDATE_STATUS}" == "" ]; then
+    fail "${UPDATE_LIST}" "https://github.com/sparkbox/standard/blob/main/security/mac-updates.md"
+  else
+    success "${UPDATE_STATUS}"
+  fi
+}
+
 echo "Today is $(date)"
 
 echo "Getting sudo access..."
 sudo ls &> /dev/null
 echo "";
 
-start "Checking Time Machine Backup Disk Encryption"
-# Replace spaces with three underscores so we can use spaces as a delimiter in an array
-TIME_MACHINE_VOLUMES=$(tmutil destinationinfo | grep -e "Name" | sed 's/Name.*: //' | sed -e "s/ /___/g")
-
-if [ "${TIME_MACHINE_VOLUMES}" == "" ]; then
-  warning "No backup disks configured with Time Machine." "https://github.com/sparkbox/standard/blob/main/security/security_policy_compliance/timemachine.md#first-time-setup"
-fi
-
-for VOLUME in $TIME_MACHINE_VOLUMES; do
-  VOLUME_NAME=$(echo ${VOLUME} | sed -e "s/___/ /g")
-  VOLUME_INFO=$(diskutil info "${VOLUME_NAME}" 2> /dev/null)
-  VOLUME_TYPE=$(get_volume_attribute "Type (Bundle)" "${VOLUME_INFO}")
-
-  case $VOLUME_TYPE in
-    # APFS volumes will identify their encryption status under "FileValt"
-    "apfs")
-      VOLUME_ENCRYPTED=$(get_volume_attribute "FileVault" "${VOLUME_INFO}")
-      ;;
-    # Core Storage volumes (Journaled HFS+) will identify their encryption status under "Encrypted"
-    *)
-      VOLUME_ENCRYPTED=$(get_volume_attribute "Encrypted" "${VOLUME_INFO}")
-      ;;
-  esac
-
-  case $VOLUME_ENCRYPTED in
-    Yes)
-      success "\"${VOLUME_NAME}\" is encrypted."
-      ;;
-    No)
-      fail "\"${VOLUME_NAME}\" is not encrypted." "https://github.com/sparkbox/standard/blob/main/security/timemachine.md"
-      ;;
-    *)
-      fail "Unable to locate \"${VOLUME_NAME}\". Please check your connection to this volume and try again."
-      ;;
-  esac
-done
-
-start "Checking for FileVault full disk encryption"
-FILEVAULT_STATUS="$(fdesetup status)"
-
-echo "${FILEVAULT_STATUS}" | grep 'FileVault is On' &> /dev/null
-if [ $? != 0 ]; then
-  fail "${FILEVAULT_STATUS}" "https://github.com/sparkbox/standard/blob/main/security/filevault.md"
-else
-  success "${FILEVAULT_STATUS}"
-fi
-
-start "Checking for software updates"
-UPDATE_LIST="$(sudo softwareupdate -l 2>&1)"
-UPDATE_STATUS="$(echo "${UPDATE_LIST}" | grep 'No new software available\.')"
-
-if [ "${UPDATE_STATUS}" == "" ]; then
-  fail "${UPDATE_LIST}" "https://github.com/sparkbox/standard/blob/main/security/mac-updates.md"
-else
-  success "${UPDATE_STATUS}"
-fi
+validate_time_machine
+validate_full_disk_encryption
+validate_software_updates


### PR DESCRIPTION
This reflects a hardware/continuity policy change that makes backups optional.

When Time machine backups are not configured, the lack of volume encryption is expected... there are no backup volumes to encrypt.

To test this:

  1. Run the `policy-script.sh` while backups are configured and the drive is connected. You should expect a ✅  for an encrypted backup volume.
  2. Eject the same volume and run the script. You should get a "⚠️".
  3. In time machine preferences, disable time machine by Removing the disk. Run the script and you should get a ✅  saying "Backups not configured."

