### PR TITLE
fix: drop $ from sudo softwareupdate line

### DIFF
--- a/security/security_policy_compliance/mac-updates.md
+++ b/security/security_policy_compliance/mac-updates.md
@@ -31,7 +31,7 @@ message that includes _Your Mac is up to date_.
 You can install updates from the command line using the `softwareupdate` tool.
 To install recommended updates with progress indication run:
 
-    $ sudo softwareupdate -ir --verbose
+    sudo softwareupdate -ir --verbose
 
 ## Installing Updates from the App Store
 


### PR DESCRIPTION
When you use the _copy_ button, it copies everything, including the `$`. If you paste that into the command line, you get an error, because `$` is not a command. By dropping it, you should be able to hit the _copy_ button and paste the command directly into your command line without a problem.