### PR TITLE
update sparkbox website links

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ How we dance.
 _Inspired by [Thoughtbot's Playbook][inspiration]_
 
 [inspiration]: https://playbook.thoughtbot.com
-[sparkbox]: http://seesparkbox.com
+[sparkbox]: http://sparkbox.com

--- a/accessibility/introduction/README.md
+++ b/accessibility/introduction/README.md
@@ -4,7 +4,7 @@
 
 ### Build Right, Build Better, Build Accessibly
 
-For a long time, Sparkbox has had the goal to build right and to build a better web. In the past couple of years, we have invested in and focused on web accessibility as part of these goals: leveling up our developers with [certifications](https://www.accessibilityassociation.org/certification), bringing in people to do usability testing in person, and having a [Maker Series](https://seesparkbox.com/foundry/derek_featherstone_web_accessibility_and_inclusive_design) dedicated to the topic. We believe that all websites should be built accessibly and that accessibility should be a part of our whole process rather than a task we do at the end of a project. By prioritizing accessibility, we build websites that enable a wider audience to access the web while also providing a useful and enjoyable user experience.
+For a long time, Sparkbox has had the goal to build right and to build a better web. In the past couple of years, we have invested in and focused on web accessibility as part of these goals: leveling up our developers with [certifications](https://www.accessibilityassociation.org/certification), bringing in people to do usability testing in person, and having a [Maker Series](https://sparkbox.com/foundry/derek_featherstone_web_accessibility_and_inclusive_design) dedicated to the topic. We believe that all websites should be built accessibly and that accessibility should be a part of our whole process rather than a task we do at the end of a project. By prioritizing accessibility, we build websites that enable a wider audience to access the web while also providing a useful and enjoyable user experience.
 
 
 ### WCAG 2.1 AA Principles Compliance

--- a/build_process/drops.md
+++ b/build_process/drops.md
@@ -41,4 +41,4 @@ Also included is a link to view the differences between the previous Release Tag
 [github-flow]: https://guides.github.com/introduction/flow/index.html
 [sparkbox-git-style]: https://github.com/sparkbox/how_to/tree/master/style/git
 [sparkbox-code-reviews]: https://github.com/sparkbox/how_to/tree/master/style/code_reviews
-[sparkbox-content-priority]: https://seesparkbox.com/foundry/content_priority_guide
+[sparkbox-content-priority]: https://sparkbox.com/foundry/content_priority_guide

--- a/career/tech-lead-role.md
+++ b/career/tech-lead-role.md
@@ -83,7 +83,7 @@
 
 
 
-*   [Making the Leap to Tech Lead (Article, Cromwell)](https://seesparkbox.com/foundry/making_the_leap_to_tech_lead)
+*   [Making the Leap to Tech Lead (Article, Cromwell)](https://sparkbox.com/foundry/making_the_leap_to_tech_lead)
 *   [Making the Leap to Tech Lead (Video, Cromwell)](https://www.youtube.com/watch?v=Lx8BepRpfvg&feature=youtu.be&list=PL6De8qQmbLARL4YgjgJqa3cP83EcXRIrI)
 *   Build Right: Sustainable Software
     *   [Full Day Slides](https://drive.google.com/open?id=1RAdv_2EtRcZEZri-zUaaFXi8supTduC__Cr97UEj4fE)

--- a/code-style/code_reviews/README.md
+++ b/code-style/code_reviews/README.md
@@ -16,5 +16,5 @@ Don't be a one person wolf pack. If for some reason we have a project with only 
 
 ## Additional Reading
 
-- [Code Review](https://seesparkbox.com/foundry/code_review)
-- [Stop Giving Depressing Code Reviews](https://seesparkbox.com/foundry/stop_giving_depressing_code_reviews)
+- [Code Review](https://sparkbox.com/foundry/code_review)
+- [Stop Giving Depressing Code Reviews](https://sparkbox.com/foundry/stop_giving_depressing_code_reviews)

--- a/code-style/git/PULL_REQUEST_TEMPLATE.md
+++ b/code-style/git/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ See Story: [ISSUE_NUMBER](ISSUE_URL)
 * [ ] This PR has code changes, and our linters still pass.
 * [ ] This PR affects production code, so it was browser tested (see below).
 * [ ] This PR has new code, so new tests were added or updated, and they pass.
-* [ ] This PR has new SCSS functions, mixins, or variables, so [Sass Tests](https://seesparkbox.com/foundry/how_and_why_we_unit_test_our_sass) were added or updated, and they pass.
+* [ ] This PR has new SCSS functions, mixins, or variables, so [Sass Tests](https://sparkbox.com/foundry/how_and_why_we_unit_test_our_sass) were added or updated, and they pass.
 * [ ] This PR has copy changes, so copy was proofread and approved.
 * [ ] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. Along with accessibility information if pertinent.
 

--- a/code-style/git/README.md
+++ b/code-style/git/README.md
@@ -319,14 +319,14 @@ Voila! You're done. You've successfully rebased a branch onto the master branch!
 
 ## Additional Resources
 
-- [GitHub Pull Requests for Everyone](https://seesparkbox.com/foundry/github_pull_requests_for_everyone) by Catherine Meade
-- [Give Better Pull Requests With Screencasts](https://seesparkbox.com/foundry/give_better_pull_requests_with_screencasts) by Ethan Muller
-- [Stop Giving Depressing Code Reviews](https://seesparkbox.com/foundry/stop_giving_depressing_code_reviews) by Bryan Braun
-- [Git is a SHA Management Tool](https://seesparkbox.com/foundry/use_git_commands_git_reset_git_log_git_reflog_git_cherry-pick_to_manage_shas) by Melissa Thompson
-- [I Screwed Up Git; How Do I Fix It?](https://seesparkbox.com/foundry/solutions_to_github_issues_with_git_merges_and_commits) by Catherine Meade
-- [Better Pull Requests & Merge Requests With Templates](https://seesparkbox.com/foundry/better_pull_requests_merge_requests_with_templates) by Patrick Fulton
-- [To Squash or Not to Squash?](https://seesparkbox.com/foundry/to_squash_or_not_to_squash) by Divya Sasidharan
-- [How to Not Dread Rebases When Managing Long-Lived Feature Branches](https://seesparkbox.com/foundry/how_to_not_dread_rebases_when_managing_long_lived_feature_branches) by Adam Simpson
+- [GitHub Pull Requests for Everyone](https://sparkbox.com/foundry/github_pull_requests_for_everyone) by Catherine Meade
+- [Give Better Pull Requests With Screencasts](https://sparkbox.com/foundry/give_better_pull_requests_with_screencasts) by Ethan Muller
+- [Stop Giving Depressing Code Reviews](https://sparkbox.com/foundry/stop_giving_depressing_code_reviews) by Bryan Braun
+- [Git is a SHA Management Tool](https://sparkbox.com/foundry/use_git_commands_git_reset_git_log_git_reflog_git_cherry-pick_to_manage_shas) by Melissa Thompson
+- [I Screwed Up Git; How Do I Fix It?](https://sparkbox.com/foundry/solutions_to_github_issues_with_git_merges_and_commits) by Catherine Meade
+- [Better Pull Requests & Merge Requests With Templates](https://sparkbox.com/foundry/better_pull_requests_merge_requests_with_templates) by Patrick Fulton
+- [To Squash or Not to Squash?](https://sparkbox.com/foundry/to_squash_or_not_to_squash) by Divya Sasidharan
+- [How to Not Dread Rebases When Managing Long-Lived Feature Branches](https://sparkbox.com/foundry/how_to_not_dread_rebases_when_managing_long_lived_feature_branches) by Adam Simpson
 
 [angularc]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#
 [karmac]: http://karma-runner.github.io/0.8/dev/git-commit-msg.html
@@ -334,12 +334,12 @@ Voila! You're done. You've successfully rebased a branch onto the master branch!
 [tpope]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [Draft PR]: https://github.blog/2019-02-14-introducing-draft-pull-requests/
 [pull request]: https://help.github.com/articles/using-pull-requests
-[Sparkbox]: http://seesparkbox.com
-[pull request template]: https://seesparkbox.com/foundry/better_pull_requests_merge_requests_with_templates
+[Sparkbox]: http://sparkbox.com
+[pull request template]: https://sparkbox.com/foundry/better_pull_requests_merge_requests_with_templates
 [example PR template]: ./PULL_REQUEST_TEMPLATE.md
 [example issue template]: ./ISSUE_TEMPLATE.md
 [Create a branch]: #naming-branches
 [curate your commit history]: #curating-your-commit-history
 [Conventional Commits]: https://www.conventionalcommits.org/en/v1.0.0/
-[Taking Control of your Commit History]: https://seesparkbox.com/foundry/take_control_of_your_commit_history
+[Taking Control of your Commit History]: https://sparkbox.com/foundry/take_control_of_your_commit_history
 [foundry_curated_commits]: https://sparkbox.com/foundry/interactive_rebasing_curates_commits_to_speed_up_pull_request_review_process

--- a/code-style/pattern_libraries/README.md
+++ b/code-style/pattern_libraries/README.md
@@ -1,6 +1,6 @@
 # Pattern Libraries
 
-What do we consider a "[pattern library](https://seesparkbox.com/foundry/building_pattern_libraries_in_react_with_storybook)" to be, exactly? At Sparkbox, our pattern libraries typically consist of all of the "components" that make up a project. We usually combine those components into larger pieces or entire "pages" so that we have some kind of static representation of how the components are used.
+What do we consider a "[pattern library](https://sparkbox.com/foundry/building_pattern_libraries_in_react_with_storybook)" to be, exactly? At Sparkbox, our pattern libraries typically consist of all of the "components" that make up a project. We usually combine those components into larger pieces or entire "pages" so that we have some kind of static representation of how the components are used.
 
 Ultimately, what we end up with is a guide for those who are implementing those static components and pages into larger systems, and those who will use our components to build off of in the future.
 

--- a/code-style/scss/README.md
+++ b/code-style/scss/README.md
@@ -263,5 +263,5 @@ Future developers will be able to learn a lot about this piece of code by the cl
 
 - [ITCSS: Scalable and Maintainable CSS Architecture](https://www.xfive.co/blog/itcss-scalable-maintainable-css-architecture/)
 - [BEM Website](http://getbem.com)
-- [BEM by Example](https://seesparkbox.com/foundry/bem_by_example)
-- [Thoughtful CSS Architecture](https://seesparkbox.com/foundry/thoughtful_css_architecture)
+- [BEM by Example](https://sparkbox.com/foundry/bem_by_example)
+- [Thoughtful CSS Architecture](https://sparkbox.com/foundry/thoughtful_css_architecture)

--- a/culture/remote/README.md
+++ b/culture/remote/README.md
@@ -53,6 +53,6 @@ Here are some links to articles and videos we love.
 [State Of Remote Work 2019]: https://buffer.com/state-of-remote-work-2019
 [The 5 Ways We Build Trust on a Fully Remote Team and Why It’s So Valuable]: https://open.buffer.com/trust-remote-team/
 [Why do remote meetings suck so much?]: https://chelseatroy.com/2018/03/29/why-do-remote-meetings-suck-so-much/
-[Effective Collaboration in Remote Project Management]: https://seesparkbox.com/foundry/effective_collaboration_in_remote_project_management
+[Effective Collaboration in Remote Project Management]: https://sparkbox.com/foundry/effective_collaboration_in_remote_project_management
 [The Ultimate Guide to Remote Meetings 2019]: https://slackhq.com/ultimate-guide-remote-meetings
 [All Remote]: https://about.gitlab.com/company/culture/all-remote/

--- a/development_process/README.md
+++ b/development_process/README.md
@@ -50,4 +50,4 @@ The release phase is when we begin sending our built artifacts to production.
 We don’t believe in a “big bang” release structure, as this presents too much risk and not enough flexibility to ensure we’re building the right thing early on. We believe in releasing the smallest parts of our application as early as possible. This makes the flexibility required in our improve phase possible.
 
 ### Release Often
-Through the use of [feature flags](https://seesparkbox.com/foundry/feature_flags_continuous_deployment), we can ensure that we can track our changes and roll them back quickly without a separate deploy. This mitigates a lot of the risk in deploying new features.
+Through the use of [feature flags](https://sparkbox.com/foundry/feature_flags_continuous_deployment), we can ensure that we can track our changes and roll them back quickly without a separate deploy. This mitigates a lot of the risk in deploying new features.

--- a/how-we-work-together.md
+++ b/how-we-work-together.md
@@ -304,7 +304,7 @@ In support of **creating, reviewing, and feedback** during a project we know it 
 
     * creating and maintaining a clear and efficient project setup through automation and Readme’s
 
-    * [providing respectful](https://seesparkbox.com/foundry/github_pull_requests_for_everyone), [constructive critique of code](https://seesparkbox.com/foundry/stop_giving_depressing_code_reviews), architecture, designs, and other project artifacts
+    * [providing respectful](https://sparkbox.com/foundry/github_pull_requests_for_everyone), [constructive critique of code](https://sparkbox.com/foundry/stop_giving_depressing_code_reviews), architecture, designs, and other project artifacts
 
 ### We Pursue Quality, Usability, Beauty, and Sustainability 
 
@@ -328,9 +328,9 @@ In support of **quality, usability, beauty, and sustainability** we feel a stron
 
     * create and follow cohesive naming conventions and file structures
 
-    * be aware of, use, and recommend [software patterns and practices](https://seesparkbox.com/foundry/javascript_design_patterns) which lend to well structured code
+    * be aware of, use, and recommend [software patterns and practices](https://sparkbox.com/foundry/javascript_design_patterns) which lend to well structured code
 
-    * implement automated tests to form an [appropriate test suite shape](https://seesparkbox.com/foundry/mow_your_own_yard)
+    * implement automated tests to form an [appropriate test suite shape](https://sparkbox.com/foundry/mow_your_own_yard)
 
 ### We Share Development Learnings and Embrace Improvement
 
@@ -338,11 +338,11 @@ In support of **learning, teaching, and improving** we recognize the importance 
 
 * Leveling up our teammates, client teams, and clarifying our own understanding through in-project mentorship, pairing, and demos
 
-* Constantly replenishing the industry’s talent pool by actively participating in Sparkbox [apprenticeships](http://apprentices.seesparkbox.com/) through office hours, pairing, responding to Slack questions, and presenting curriculum topics
+* Constantly replenishing the industry’s talent pool by actively participating in Sparkbox [apprenticeships](http://apprentices.sparkbox.com/) through office hours, pairing, responding to Slack questions, and presenting curriculum topics
 
 * Sharing our knowledge, expertise, and experience with the industry through workshops and presentations at conferences and meetups
 
-* Giving [thoughtful responses on Pull Requests](https://seesparkbox.com/foundry/stop_giving_depressing_code_reviews) and Slack questions, such as:
+* Giving [thoughtful responses on Pull Requests](https://sparkbox.com/foundry/stop_giving_depressing_code_reviews) and Slack questions, such as:
 
     * offering references, explanations, and reasoning behind suggestions
 

--- a/labs_process.md
+++ b/labs_process.md
@@ -1,6 +1,6 @@
 # How to Get Something Added to Labs
 
 1. Do something cool _outside of_ client work (Examples of work you could include are: Open-Source Projects, Cotton Bureau submissions, Slides/Speaker Deck links, Videos of a Talk, Podcasts, Hackday Results, Dribbble Stuff...).
-2. Add details about this project to the Labs yml file - https://github.com/sparkbox/seesparkbox.com/blob/labs-addition/static/data/labs/page-data.yml
+2. Add details about this project to the Labs yml file - https://github.com/sparkbox/sparkbox.com/blob/labs-addition/static/data/labs/page-data.yml
 3. Put in a PR and holler at Emily.
 4. Bask in your Labsy glory.

--- a/labs_process.md
+++ b/labs_process.md
@@ -1,6 +1,6 @@
 # How to Get Something Added to Labs
 
 1. Do something cool _outside of_ client work (Examples of work you could include are: Open-Source Projects, Cotton Bureau submissions, Slides/Speaker Deck links, Videos of a Talk, Podcasts, Hackday Results, Dribbble Stuff...).
-2. Add details about this project to the Labs yml file - https://github.com/sparkbox/sparkbox.com/blob/labs-addition/static/data/labs/page-data.yml
+2. Add details about this project to the Labs yml file - https://github.com/sparkbox/seesparkbox.com/blob/labs-addition/static/data/labs/page-data.yml
 3. Put in a PR and holler at Emily.
 4. Bask in your Labsy glory.

--- a/office/email-signature.md
+++ b/office/email-signature.md
@@ -10,7 +10,7 @@ Sparkbox, Creative Director
 123 Webster Street, Studio 2
 Dayton, OH 45402
 937.401.0915
-www.seesparkbox.com
+www.sparkbox.com
 ```
 
 - First line - `Arial, Bold, 16px, #33717a`

--- a/platforms/cms.md
+++ b/platforms/cms.md
@@ -1,6 +1,6 @@
 # CMS Platforms
 
-For many years, Sparkbox has relied on and recommended [ExpressionEngine] as the CMS of choice. In fact, ExpressionEngine continues to power https://seesparkbox.com. Today, we recommend one of two CMS platforms:
+For many years, Sparkbox has relied on and recommended [ExpressionEngine] as the CMS of choice. In fact, ExpressionEngine continues to power https://sparkbox.com. Today, we recommend one of two CMS platforms:
 
 ## [CraftCMS]
 

--- a/project_management/base-hub.md
+++ b/project_management/base-hub.md
@@ -1,4 +1,4 @@
-This is an example of a centralized repository of project information. Having a clear, easy-to-use place that everyone can find what they need at any time is crucial, especially when handling large projects with lots of moving parts and teammembers. [Additional details on the Project Hub](http://seesparkbox.com/foundry/project_hub).
+This is an example of a centralized repository of project information. Having a clear, easy-to-use place that everyone can find what they need at any time is crucial, especially when handling large projects with lots of moving parts and teammembers. [Additional details on the Project Hub](http://sparkbox.com/foundry/project_hub).
 
 #Table of Contents
 - [Environments](#environments)

--- a/project_management/site_completeness_checklist.md
+++ b/project_management/site_completeness_checklist.md
@@ -113,7 +113,7 @@ Devices
 * [ ] add modernizr only if needed
 * [ ] build custom version of modernizr (keep file small)
 * [ ] Transition Typeography.com fonts to Production mode
-* [ ] Assure [assets are fingerprinted](https://seesparkbox.com/foundry/automation_ftw_bust_your_cache) possibly with [`cachebust`](https://github.com/sparkbox/cachebust)
+* [ ] Assure [assets are fingerprinted](https://sparkbox.com/foundry/automation_ftw_bust_your_cache) possibly with [`cachebust`](https://github.com/sparkbox/cachebust)
 
 ### Server Related
 
@@ -141,7 +141,7 @@ bugs, etc.
 ### Marketing
 
 * [ ] Submit to Galleries
-* [ ] Add to seesparkbox.com work section
+* [ ] Add to sparkbox.com work section
 * [ ] Blog about launch
 * [ ] Tweet from @hearsparkbox
 * [ ] Request client quote/recommendation (if appropriate).

--- a/services/slack/README.md
+++ b/services/slack/README.md
@@ -31,7 +31,7 @@ The channel for sharing interesting conferences, Call for Speakers, and planning
 Channels to discuss office-specific happenings, such as lunch plans.
 
 ##### #-gems
-A collection of quotations from your Sparkbox community, curated in part by **gem-me-bot**. Share a gem publicly with the `:earth-americas:` reaction, or hide it from the public eye with the `:x:` response. There's even [a Foundry article](https://seesparkbox.com/foundry/sparkbox_gems) if you'd like to learn more.
+A collection of quotations from your Sparkbox community, curated in part by **gem-me-bot**. Share a gem publicly with the `:earth-americas:` reaction, or hide it from the public eye with the `:x:` response. There's even [a Foundry article](https://sparkbox.com/foundry/sparkbox_gems) if you'd like to learn more.
 
 ##### #-know-your-company
 A place to discuss fun facts about coworkers, along with weekly KYC email answers.

--- a/software/README.md
+++ b/software/README.md
@@ -1,6 +1,6 @@
 # Software
 
-Software [we](https://seesparkbox.com) prefer to use when the need arises.
+Software [we](https://sparkbox.com) prefer to use when the need arises.
 
 * **[Apache](apache)**
 * **[SSH](ssh)**

--- a/web-fundamentals/README.md
+++ b/web-fundamentals/README.md
@@ -12,6 +12,6 @@ There are a lot of topics and skills that go into building for the web. We recog
 
 
 [career growth]: https://www.figma.com/proto/0FdKsjKvwf2H6KQpgRvT9Q/Sparkbox-Developer-Career-Growth-Framework?scaling=scale-down-width&hide-ui=1
-[apprenticeship]: https://apprentices.seesparkbox.com
+[apprenticeship]: https://apprentices.sparkbox.com
 [html-css]: ./html-css/
 [build-tooling]: ./build-tools-and-project-setup/


### PR DESCRIPTION
In working through our onboarding materials I was noticing links in the standard to `https://seesparkbox.com` were not redirecting appropriately. 

To Address this:

- replaces links going to `seesparkbox.com` with `sparkbox.com` 

- update references to `seesparkbox.com` to `sparkbox.com` (email-signature, cms, site_completeness_checklist)

- The sparkbox-com slack channel has been notified about potential redirect issue

**Note:** I did not change the use of seesparkbox.com with in the link to the github repo for sparkbox.com, I do not have access to this repo so I was not able to confirm that the repo name is still seesparkbox, let me know if it has changed to sparkbox and I can adjust. 
`https://github.com/sparkbox/seesparkbox.com/blob/labs-addition/static/data/labs/page-data.yml` 

