### PR TITLE
feat: make only minor and patch OS updates required in security policy script

### DIFF
--- a/security/security_policy_compliance/policy-checks.sh
+++ b/security/security_policy_compliance/policy-checks.sh
@@ -11,7 +11,7 @@ function fail {
 
   echo "❌ \033[1;31m${DETAILS}\033[0m";
   if [ "${HELP_URL}" != "" ]; then
-    echo "\033[1;37m${HELP_URL}\031"
+    echo "\n\033[1;37m${HELP_URL}\031"
   fi
   echo ""
 }
@@ -95,16 +95,71 @@ function validate_full_disk_encryption {
 
 }
 
+function get_major_version {
+  echo $@ | awk -F '.' '{print $1}'
+}
+
+function get_minor_patch_versions {
+  echo $@ | awk -F '.' '{print $2 "." $3}'
+}
+
 function validate_software_updates {
   start "Checking for software updates"
   UPDATE_LIST="$(sudo softwareupdate -l 2>&1)"
-  UPDATE_STATUS="$(echo "${UPDATE_LIST}" | grep 'No new software available\.')"
+  SUCCESS_STATUS="$(echo "${UPDATE_LIST}" | grep 'No new software available\.')"
 
-  if [ "${UPDATE_STATUS}" == "" ]; then
-    fail "${UPDATE_LIST}" "https://github.com/sparkbox/standard/blob/main/security/mac-updates.md"
-  else
-    success "${UPDATE_STATUS}"
+  if [ "${SUCCESS_STATUS}" != "" ]; then
+    success "${SUCCESS_STATUS}"
+    return
   fi
+
+  # The string to search for macOS updates
+  OS="Title: macOS"
+
+  # find all updates that are not OS updates
+  REQUIRED_SOFTWARE_UPDATES="$(echo "${UPDATE_LIST}" | grep "Title: " | grep --invert-match "$OS")"
+
+  # get the user's current MacOS version
+  MACHINE_MAC_OS_VERSION="$(sw_vers -productVersion)"
+
+  # find available minor / patch version updates
+  # updates within the same major version of the user
+  # indicate that a minor or patch update is available
+  # security updates are typically patches
+  MAC_OS_UPDATE_MINOR_VERSION="$(echo "${UPDATE_LIST}" | grep "$OS" \
+    | grep "Version: $(get_major_version $MACHINE_MAC_OS_VERSION)" \
+    | awk -F ', ' '{print $2}' | awk -F ': ' '{print $2}')"
+
+  # find available major version upgrades
+  # updates that are NOT within the user's current major version
+  # indicate that a major version upgrade is available
+  MAC_OS_UPDATE_MAJOR_VERSION=$(echo "${UPDATE_LIST}" | grep "$OS" \
+    | grep --invert-match "Version: $(get_major_version $MACHINE_MAC_OS_VERSION)")
+
+  # major OS version upgrades are not strictly required
+  # due to differing needs and preferences
+  # people may be unable to upgrade due to project dependencies
+  # or may prefer to wait out the initial release bugs
+  if [ "$MAC_OS_UPDATE_MAJOR_VERSION" != '' ]; then
+    echo "⭐️ A newer Mac OS version is available. This upgrade is not required, but recommended:"
+    echo "$MAC_OS_UPDATE_MAJOR_VERSION"
+    echo ""
+  fi
+
+  if [ "$REQUIRED_SOFTWARE_UPDATES" = '' ] && [ "$MAC_OS_UPDATE_MINOR_VERSION" = '' ]; then
+    success "No security updates required!"
+    return;
+  fi
+
+  # because security updates are typically patches, they're required
+  # this currently requires minor version updates as well, but that may be overkill
+  if [ "$MAC_OS_UPDATE_MINOR_VERSION" != $MACHINE_MAC_OS_VERSION ]; then
+    fail "A MacOS update is required:\n\n\tCurrent machine OS version:\t$MACHINE_MAC_OS_VERSION\n\tNeeds updated to version:\t$MAC_OS_UPDATE_MINOR_VERSION" "https://github.com/sparkbox/standard/blob/main/security/mac-updates.md"
+  fi
+
+   if [ "$REQUIRED_SOFTWARE_UPDATES" != '' ]; then
+    fail "Software updates required:\n\n${REQUIRED_SOFTWARE_UPDATES}" "https://github.com/sparkbox/standard/blob/main/security/mac-updates.md"
+   fi
 }
 
 echo "Today is $(date)"


### PR DESCRIPTION
Updates the security script output to only consider minor/patch updates required. Security patches are typically patch fixes. Major OS updates are not required for security compliance.

![image](https://user-images.githubusercontent.com/565751/226478747-90d71dc0-3feb-48b0-9592-c126759acde3.png)

## Validation
1. Check out this branch
2. Download [test.patch.gz](https://github.com/sparkbox/standard/files/11023519/test.patch.gz)
3. Run `gunzip test.patch.gz && git apply test.patch` to apply testing patch. This reads a mock `test.txt` file instead of running the actual `softwareupdate` command.
4. `test.txt` includes 3 updates:
    - A software update (Safari)
    - A MacOS patch version update
    - A MacOS major version update
6. Run `./security/security_policy_compliance/policy-checks.sh`
7. The output should show:
    - A **recommendation** to upgrade the major OS version
    - A **requirement** to update OS from `12.6.2` to `12.6.3`
    - A **requirement** for a Safari update
8. Removing corresponding lines from the test file should remove the above recs/requirements appropriately
9. If only the major OS update exists, the recommendation shows, but the step displays as passing