### PR TITLE
fix: update link in security policy check for mac updates

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -39,8 +39,8 @@
 [General Policy]: ./security/README.md#general-policy
 [Instructions]: ./security/README.md#instructions
 [Recommended Mac Updates]: ./security/mac-updates.md
-[Time Machine Backup Disk Encryption]: ./security/timemachine.md
-[Filevault Full Disk Encryption]: ./security/filevault.md
+[Time Machine Backup Disk Encryption]: ./security/security_policy_compliance/timemachine.md
+[Filevault Full Disk Encryption]: ./security/security_policy_compliance/filevault.md
 [Device Security]: ./security/devices.md
 [Verified Git Commits]: ./security/verified-commits.md
 [Drops Process]: ./build_process/drops.md

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -35,13 +35,13 @@
 [IE11]: ./almanac/IE11.md
 [General]: ./almanac/general.md
 [Principles]: ./security/README.md#principles
-[Two Factor Authentication]: ./security/two-factor-authentication.md
+[Two Factor Authentication]: ./security/security_policy_compliance/two-factor-authentication.md
 [General Policy]: ./security/README.md#general-policy
 [Instructions]: ./security/README.md#instructions
-[Recommended Mac Updates]: ./security/mac-updates.md
+[Recommended Mac Updates]: ./security/security_policy_compliance/mac-updates.md
 [Time Machine Backup Disk Encryption]: ./security/security_policy_compliance/timemachine.md
 [Filevault Full Disk Encryption]: ./security/security_policy_compliance/filevault.md
-[Device Security]: ./security/devices.md
-[Verified Git Commits]: ./security/verified-commits.md
+[Device Security]: ./security/security_policy_compliance/devices.md
+[Verified Git Commits]: ./security/security_policy_compliance/verified-commits.md
 [Drops Process]: ./build_process/drops.md
 [Site Completeness Checklist]: ./project_management/site_completeness_checklist.md

--- a/security/security_policy_compliance/policy-checks.sh
+++ b/security/security_policy_compliance/policy-checks.sh
@@ -154,11 +154,11 @@ function validate_software_updates {
   # because security updates are typically patches, they're required
   # this currently requires minor version updates as well, but that may be overkill
   if [ "$MAC_OS_UPDATE_MINOR_VERSION" != $MACHINE_MAC_OS_VERSION ]; then
-    fail "A MacOS update is required:\n\n\tCurrent machine OS version:\t$MACHINE_MAC_OS_VERSION\n\tNeeds updated to version:\t$MAC_OS_UPDATE_MINOR_VERSION" "https://github.com/sparkbox/standard/blob/main/security/mac-updates.md"
+    fail "A MacOS update is required:\n\n\tCurrent machine OS version:\t$MACHINE_MAC_OS_VERSION\n\tNeeds updated to version:\t$MAC_OS_UPDATE_MINOR_VERSION" "https://github.com/sparkbox/standard/blob/main/security/security_policy_compliance/mac-updates.md"
   fi
 
    if [ "$REQUIRED_SOFTWARE_UPDATES" != '' ]; then
-    fail "Software updates required:\n\n${REQUIRED_SOFTWARE_UPDATES}" "https://github.com/sparkbox/standard/blob/main/security/mac-updates.md"
+    fail "Software updates required:\n\n${REQUIRED_SOFTWARE_UPDATES}" "https://github.com/sparkbox/standard/blob/main/security/security_policy_compliance/mac-updates.md"
    fi
 }
 

--- a/security/security_policy_compliance/policy-checks.sh
+++ b/security/security_policy_compliance/policy-checks.sh
@@ -73,7 +73,7 @@ function validate_time_machine {
         success "\"${VOLUME_NAME}\" is encrypted."
         ;;
       No)
-        fail "\"${VOLUME_NAME}\" is not encrypted." "https://github.com/sparkbox/standard/blob/main/security/timemachine.md"
+        fail "\"${VOLUME_NAME}\" is not encrypted." "https://github.com/sparkbox/standard/blob/main/security/security_policy_compliance/timemachine.md"
         ;;
       *)
         fail "Unable to locate \"${VOLUME_NAME}\". Please check your connection to this volume and try again."
@@ -88,7 +88,7 @@ function validate_full_disk_encryption {
 
   echo "${FILEVAULT_STATUS}" | grep 'FileVault is On' &> /dev/null
   if [ $? != 0 ]; then
-    fail "${FILEVAULT_STATUS}" "https://github.com/sparkbox/standard/blob/main/security/filevault.md"
+    fail "${FILEVAULT_STATUS}" "https://github.com/sparkbox/standard/blob/main/security/security_policy_compliance/filevault.md"
   else
     success "${FILEVAULT_STATUS}"
   fi


### PR DESCRIPTION
Solves #257 and additional links provided during review.

## How to review
- [ ] Confirm the new link for mac-updates.md
- [ ] Confirm the new link for timemachine.md
- [ ] Confirm the new link for filevault.md
- [ ] Confirm the new link for two-factor-authentication.md
- [ ] Confirm the new link for mac-updates.md
- [ ] Confirm the new link for devices.md
- [ ] Confirm the new link for verified-commits.md